### PR TITLE
Update keycloak to 22.0.1, Re-export common interfaces in index.d.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file. See [commit-and-tag-version](https://github.com/absolute-version/commit-and-tag-version) for commit guidelines.
 
+## [22.0.1](https://github.com//s3pweb/keycloak-admin-client-cjs/compare/v21.0.1...v22.0.1) (2023-08-07)
+
+### Features
+
+* **keycloak:** re-export common keycloak interfaces in index.d.ts
+
+### Other
+
+* **deps:** bump @keycloak/keycloak-admin-client from 20.0.3 to 21.0.1 ([45157bf](https://github.com//s3pweb/keycloak-admin-client-cjs/commit/45157bfd49abbb56a220135161873d558ed2bf84))
+
 ## [21.0.1](https://github.com//s3pweb/keycloak-admin-client-cjs/compare/v20.0.3...v21.0.1) (2023-03-07)
 
 

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,28 +1,139 @@
-import KeycloakAdminClient from '@keycloak/keycloak-admin-client';
-import UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation';
-import GroupRepresentation from '@keycloak/keycloak-admin-client/lib/defs/groupRepresentation';
-import RealmRepresentation from '@keycloak/keycloak-admin-client/lib/defs/realmRepresentation';
-import AccessTokenAccess from '@keycloak/keycloak-admin-client/lib/defs/AccessTokenAccess';
-import AccessTokenCertConf from '@keycloak/keycloak-admin-client/lib/defs/accessTokenCertConf';
-import AccessTokenRepresentation from '@keycloak/keycloak-admin-client/lib/defs/accessTokenRepresentation';
-import AccessClaimSet from '@keycloak/keycloak-admin-client/lib/defs/addressClaimSet';
-import AdminEventRepresentation from '@keycloak/keycloak-admin-client/lib/defs/adminEventRepresentation';
-import AuthDetailsRepresentation from '@keycloak/keycloak-admin-client/lib/defs/authDetailsRepresentation';
-import AuthenticationExecutionExportRepresentation
-  from '@keycloak/keycloak-admin-client/lib/defs/authenticationExecutionExportRepresentation';
-import AuthenticationExecutionInfoRepresentation from '@keycloak/keycloak-admin-client/lib/defs/authenticationExecutionInfoRepresentation';
+import KeycloakAdminClient from '@keycloak/keycloak-admin-client'
+import UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation'
+import GroupRepresentation from '@keycloak/keycloak-admin-client/lib/defs/groupRepresentation'
+import RealmRepresentation from '@keycloak/keycloak-admin-client/lib/defs/realmRepresentation'
+import AccessTokenAccess from '@keycloak/keycloak-admin-client/lib/defs/AccessTokenAccess'
+import AccessTokenCertConf from '@keycloak/keycloak-admin-client/lib/defs/accessTokenCertConf'
+import AccessTokenRepresentation from '@keycloak/keycloak-admin-client/lib/defs/accessTokenRepresentation'
+import AccessClaimSet from '@keycloak/keycloak-admin-client/lib/defs/addressClaimSet'
+import AdminEventRepresentation from '@keycloak/keycloak-admin-client/lib/defs/adminEventRepresentation'
+import AuthDetailsRepresentation from '@keycloak/keycloak-admin-client/lib/defs/authDetailsRepresentation'
+import AuthenticationExecutionExportRepresentation from '@keycloak/keycloak-admin-client/lib/defs/authenticationExecutionExportRepresentation'
+import AuthenticationExecutionInfoRepresentation from '@keycloak/keycloak-admin-client/lib/defs/authenticationExecutionInfoRepresentation'
+import AuthenticationFlowRepresentation from '@keycloak/keycloak-admin-client/lib/defs/authenticationFlowRepresentation'
+import AuthenticatorConfigInfoRepresentation from '@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigInfoRepresentation'
+import AuthenticatorConfigRepresentation from '@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigRepresentation'
+import CertificateRepresentation from '@keycloak/keycloak-admin-client/lib/defs/certificateRepresentation'
+import ClientInitialAccessPresentation from '@keycloak/keycloak-admin-client/lib/defs/clientInitialAccessPresentation'
+import ClientPoliciesRepresentation from '@keycloak/keycloak-admin-client/lib/defs/clientPoliciesRepresentation'
+import ClientPolicyConditionRepresentation from '@keycloak/keycloak-admin-client/lib/defs/clientPolicyConditionRepresentation'
+import ClientPolicyExecutorRepresentation from '@keycloak/keycloak-admin-client/lib/defs/clientPolicyExecutorRepresentation'
+import ClientPolicyRepresentation from '@keycloak/keycloak-admin-client/lib/defs/clientPolicyRepresentation'
+import ClientProfileRepresentation from '@keycloak/keycloak-admin-client/lib/defs/clientProfileRepresentation'
+import ClientProfilesRepresentation from '@keycloak/keycloak-admin-client/lib/defs/clientProfilesRepresentation'
+import ClientRepresentation from '@keycloak/keycloak-admin-client/lib/defs/clientRepresentation'
+import ClientScopeRepresentation from '@keycloak/keycloak-admin-client/lib/defs/clientScopeRepresentation'
+import { ClientSessionStat } from '@keycloak/keycloak-admin-client/lib/defs/clientSessionStat'
+import ComponentExportRepresentation from '@keycloak/keycloak-admin-client/lib/defs/componentExportRepresentation'
+import ComponentRepresentation from '@keycloak/keycloak-admin-client/lib/defs/componentRepresentation'
+import ComponentTypeRepresentation from '@keycloak/keycloak-admin-client/lib/defs/componentTypeRepresentation'
+import { ConfigPropertyRepresentation } from '@keycloak/keycloak-admin-client/lib/defs/authenticatorConfigInfoRepresentation'
+import CredentialRepresentation from '@keycloak/keycloak-admin-client/lib/defs/credentialRepresentation'
+import EvaluationResultRepresentation from '@keycloak/keycloak-admin-client/lib/defs/evaluationResultRepresentation'
+import EventRepresentation from '@keycloak/keycloak-admin-client/lib/defs/eventRepresentation'
+import EventType from '@keycloak/keycloak-admin-client/lib/defs/eventTypes'
+import FederatedIdentityRepresentation from '@keycloak/keycloak-admin-client/lib/defs/federatedIdentityRepresentation'
+import GlobalRequestResult from '@keycloak/keycloak-admin-client/lib/defs/globalRequestResult'
+import IdentityProviderMapperRepresentation from '@keycloak/keycloak-admin-client/lib/defs/identityProviderMapperRepresentation'
+import { IdentityProviderMapperTypeRepresentation } from '@keycloak/keycloak-admin-client/lib/defs/identityProviderMapperTypeRepresentation'
+import IdentityProviderRepresentation from '@keycloak/keycloak-admin-client/lib/defs/identityProviderRepresentation'
+import KeysMetadataRepresentation from '@keycloak/keycloak-admin-client/lib/defs/keyMetadataRepresentation'
+import KeyStoreConfig from '@keycloak/keycloak-admin-client/lib/defs/keystoreConfig'
+import { ManagementPermissionReference } from '@keycloak/keycloak-admin-client/lib/defs/managementPermissionReference'
+import MappingsRepresentation from '@keycloak/keycloak-admin-client/lib/defs/mappingsRepresentation'
+import PasswordPolicyTypeRepresentation from '@keycloak/keycloak-admin-client/lib/defs/passwordPolicyTypeRepresentation'
+import PermissionRepresentation from '@keycloak/keycloak-admin-client/lib/defs/PermissonRepresentation'
+import PolicyEvaluationResponse from '@keycloak/keycloak-admin-client/lib/defs/policyEvaluationResponse'
+import PolicyProviderRepresentation from '@keycloak/keycloak-admin-client/lib/defs/policyProviderRepresentation'
+import PolicyResultRepresentation from '@keycloak/keycloak-admin-client/lib/defs/policyResultRepresentation'
+import PolicyRepresentation from '@keycloak/keycloak-admin-client/lib/defs/policyRepresentation'
+import ProfileInfoRepresentation from '@keycloak/keycloak-admin-client/lib/defs/profileInfoRepresentation'
+import ProtocolMapperRepresentation from '@keycloak/keycloak-admin-client/lib/defs/protocolMapperRepresentation'
+import { RealmEventsConfigRepresentation } from '@keycloak/keycloak-admin-client/lib/defs/realmEventsConfigRepresentation'
+import RequiredActionProviderRepresentation from '@keycloak/keycloak-admin-client/lib/defs/requiredActionProviderRepresentation'
+import RequiredActionProviderSimpleRepresentation from '@keycloak/keycloak-admin-client/lib/defs/requiredActionProviderSimpleRepresentation'
+import ResourceEvaluation from '@keycloak/keycloak-admin-client/lib/defs/resourceEvaluation'
+import ResourceRepresentation from '@keycloak/keycloak-admin-client/lib/defs/resourceRepresentation'
+import ResourceServerRepresentation from '@keycloak/keycloak-admin-client/lib/defs/resourceServerRepresentation'
+import RoleRepresentation from '@keycloak/keycloak-admin-client/lib/defs/roleRepresentation'
+import RolesRepresentation from '@keycloak/keycloak-admin-client/lib/defs/rolesRepresentation'
+import ScopeRepresentation from '@keycloak/keycloak-admin-client/lib/defs/scopeRepresentation'
+import { ServerInfoRepresentation } from '@keycloak/keycloak-admin-client/lib/defs/serverInfoRepesentation'
+import SynchronizationResultRepresentation from '@keycloak/keycloak-admin-client/lib/defs/synchronizationResultRepresentation'
+import SystemInfoRepresentation from '@keycloak/keycloak-admin-client/lib/defs/systemInfoRepersantation'
+import TestLdapConnectionRepresentation from '@keycloak/keycloak-admin-client/lib/defs/testLdapConnection'
+import UserConsentRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userConsentRepresentation'
+import UserProfileConfig from '@keycloak/keycloak-admin-client/lib/defs/userProfileConfig'
+import UserSessionRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userSessionRepresentation'
+import WhoAmIRepresentation from '@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation'
 
-export {KeycloakAdminClient};
+export { KeycloakAdminClient }
 export type {
- UserRepresentation,
- GroupRepresentation,
- RealmRepresentation,
- AccessTokenAccess,
- AccessTokenRepresentation,
- AccessTokenCertConf,
- AccessClaimSet,
- AdminEventRepresentation,
- AuthenticationExecutionExportRepresentation,
- AuthDetailsRepresentation,
- AuthenticationExecutionInfoRepresentation,
-};
+  UserRepresentation,
+  GroupRepresentation,
+  RealmRepresentation,
+  AccessTokenAccess,
+  AccessTokenRepresentation,
+  AccessTokenCertConf,
+  AccessClaimSet,
+  AdminEventRepresentation,
+  AuthenticationExecutionExportRepresentation,
+  AuthDetailsRepresentation,
+  AuthenticationExecutionInfoRepresentation,
+  AuthenticationFlowRepresentation,
+  AuthenticatorConfigInfoRepresentation,
+  AuthenticatorConfigRepresentation,
+  CertificateRepresentation,
+  ClientInitialAccessPresentation,
+  ClientPoliciesRepresentation,
+  ClientPolicyConditionRepresentation,
+  ClientPolicyExecutorRepresentation,
+  ClientPolicyRepresentation,
+  ClientProfileRepresentation,
+  ClientProfilesRepresentation,
+  ClientRepresentation,
+  ClientScopeRepresentation,
+  ClientSessionStat,
+  ComponentExportRepresentation,
+  ComponentRepresentation,
+  ComponentTypeRepresentation,
+  ConfigPropertyRepresentation,
+  CredentialRepresentation,
+  EvaluationResultRepresentation,
+  EventRepresentation,
+  EventType,
+  FederatedIdentityRepresentation,
+  GlobalRequestResult,
+  IdentityProviderMapperRepresentation,
+  IdentityProviderMapperTypeRepresentation,
+  IdentityProviderRepresentation,
+  KeysMetadataRepresentation,
+  KeyStoreConfig,
+  ManagementPermissionReference,
+  MappingsRepresentation,
+  PasswordPolicyTypeRepresentation,
+  PermissionRepresentation,
+  PolicyEvaluationResponse,
+  PolicyProviderRepresentation,
+  PolicyResultRepresentation,
+  PolicyRepresentation,
+  ProfileInfoRepresentation,
+  ProtocolMapperRepresentation,
+  RealmEventsConfigRepresentation,
+  RequiredActionProviderRepresentation,
+  RequiredActionProviderSimpleRepresentation,
+  ResourceEvaluation,
+  ResourceRepresentation,
+  ResourceServerRepresentation,
+  RoleRepresentation,
+  RolesRepresentation,
+  ScopeRepresentation,
+  ServerInfoRepresentation,
+  SynchronizationResultRepresentation,
+  SystemInfoRepresentation,
+  TestLdapConnectionRepresentation,
+  UserConsentRepresentation,
+  UserProfileConfig,
+  UserSessionRepresentation,
+  WhoAmIRepresentation,
+}

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -66,6 +66,7 @@ import UserConsentRepresentation from '@keycloak/keycloak-admin-client/lib/defs/
 import UserProfileConfig from '@keycloak/keycloak-admin-client/lib/defs/userProfileConfig'
 import UserSessionRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userSessionRepresentation'
 import WhoAmIRepresentation from '@keycloak/keycloak-admin-client/lib/defs/whoAmIRepresentation'
+import { Credentials, Settings, TokenResponse, TokenResponseRaw } from '@keycloak/keycloak-admin-client/lib/utils/auth'
 
 export { KeycloakAdminClient }
 export type {
@@ -136,4 +137,8 @@ export type {
   UserProfileConfig,
   UserSessionRepresentation,
   WhoAmIRepresentation,
+  Credentials,
+  Settings,
+  TokenResponse,
+  TokenResponseRaw,
 }

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,3 +1,28 @@
 import KeycloakAdminClient from '@keycloak/keycloak-admin-client';
+import UserRepresentation from '@keycloak/keycloak-admin-client/lib/defs/userRepresentation';
+import GroupRepresentation from '@keycloak/keycloak-admin-client/lib/defs/groupRepresentation';
+import RealmRepresentation from '@keycloak/keycloak-admin-client/lib/defs/realmRepresentation';
+import AccessTokenAccess from '@keycloak/keycloak-admin-client/lib/defs/AccessTokenAccess';
+import AccessTokenCertConf from '@keycloak/keycloak-admin-client/lib/defs/accessTokenCertConf';
+import AccessTokenRepresentation from '@keycloak/keycloak-admin-client/lib/defs/accessTokenRepresentation';
+import AccessClaimSet from '@keycloak/keycloak-admin-client/lib/defs/addressClaimSet';
+import AdminEventRepresentation from '@keycloak/keycloak-admin-client/lib/defs/adminEventRepresentation';
+import AuthDetailsRepresentation from '@keycloak/keycloak-admin-client/lib/defs/authDetailsRepresentation';
+import AuthenticationExecutionExportRepresentation
+  from '@keycloak/keycloak-admin-client/lib/defs/authenticationExecutionExportRepresentation';
+import AuthenticationExecutionInfoRepresentation from '@keycloak/keycloak-admin-client/lib/defs/authenticationExecutionInfoRepresentation';
 
 export {KeycloakAdminClient};
+export type {
+ UserRepresentation,
+ GroupRepresentation,
+ RealmRepresentation,
+ AccessTokenAccess,
+ AccessTokenRepresentation,
+ AccessTokenCertConf,
+ AccessClaimSet,
+ AdminEventRepresentation,
+ AuthenticationExecutionExportRepresentation,
+ AuthDetailsRepresentation,
+ AuthenticationExecutionInfoRepresentation,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@s3pweb/keycloak-admin-client-cjs",
-  "version": "21.0.1",
+  "version": "22.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@s3pweb/keycloak-admin-client-cjs",
-      "version": "21.0.1",
+      "version": "22.0.1",
       "license": "MIT",
       "dependencies": {
-        "@keycloak/keycloak-admin-client": "21.0.1"
+        "@keycloak/keycloak-admin-client": "22.0.1"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.4.2",
@@ -761,18 +761,17 @@
       }
     },
     "node_modules/@keycloak/keycloak-admin-client": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-21.0.1.tgz",
-      "integrity": "sha512-YPVcgsQvEOQwiLqX94mX4Hn1/u5bg6eKsoBusFIOdBlrCXaG2BsVPjxZs+UIGeTw1w/FTElcVoN2Jn4zLy19cw==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-22.0.1.tgz",
+      "integrity": "sha512-/eKzNzT2hW/tRQd8/33dX1dfRU4xBsd3/30bL2OFF5+J+1UUmRYM2klYcFhdIkFX3P9/ptqH+vHpqCusdMcSCw==",
       "dependencies": {
-        "axios": "^0.27.2",
-        "camelize-ts": "^2.1.1",
+        "camelize-ts": "^3.0.0",
         "lodash-es": "^4.17.21",
         "url-join": "^5.0.0",
-        "url-template": "^3.0.0"
+        "url-template": "^3.1.0"
       },
       "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+        "node": ">=18"
       }
     },
     "node_modules/@tsconfig/node10": {
@@ -911,20 +910,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "node_modules/axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "dependencies": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -983,9 +968,9 @@
       }
     },
     "node_modules/camelize-ts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-2.2.0.tgz",
-      "integrity": "sha512-6jMy83qFmNrJIMQXXU6Bi7VVkyl/nBVvoxcVsGRDA6R01pPZpnO/LaIcx6dijJjHbBA2G0uHY4Irk7LeA274NQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-3.0.0.tgz",
+      "integrity": "sha512-cgRwKKavoDKLTjO4FQTs3dRBePZp/2Y9Xpud0FhuCOTE86M2cniKN4CCXgRnsyXNMmQMifVHcv6SPaMtTx6ofQ==",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       }
@@ -1037,17 +1022,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "node_modules/combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dependencies": {
-        "delayed-stream": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
     },
     "node_modules/commit-and-tag-version": {
       "version": "11.0.0",
@@ -1696,14 +1670,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
     "node_modules/detect-indent": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -1945,38 +1911,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/fs-extra": {
@@ -2688,25 +2622,6 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
-    },
-    "node_modules/mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "dependencies": {
-        "mime-db": "1.52.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
     },
     "node_modules/mimic-fn": {
       "version": "2.1.0",
@@ -4154,15 +4069,14 @@
       }
     },
     "@keycloak/keycloak-admin-client": {
-      "version": "21.0.1",
-      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-21.0.1.tgz",
-      "integrity": "sha512-YPVcgsQvEOQwiLqX94mX4Hn1/u5bg6eKsoBusFIOdBlrCXaG2BsVPjxZs+UIGeTw1w/FTElcVoN2Jn4zLy19cw==",
+      "version": "22.0.1",
+      "resolved": "https://registry.npmjs.org/@keycloak/keycloak-admin-client/-/keycloak-admin-client-22.0.1.tgz",
+      "integrity": "sha512-/eKzNzT2hW/tRQd8/33dX1dfRU4xBsd3/30bL2OFF5+J+1UUmRYM2klYcFhdIkFX3P9/ptqH+vHpqCusdMcSCw==",
       "requires": {
-        "axios": "^0.27.2",
-        "camelize-ts": "^2.1.1",
+        "camelize-ts": "^3.0.0",
         "lodash-es": "^4.17.21",
         "url-join": "^5.0.0",
-        "url-template": "^3.0.0"
+        "url-template": "^3.1.0"
       }
     },
     "@tsconfig/node10": {
@@ -4276,20 +4190,6 @@
       "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
       "dev": true
     },
-    "asynckit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
-    },
-    "axios": {
-      "version": "0.27.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
-      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
-      "requires": {
-        "follow-redirects": "^1.14.9",
-        "form-data": "^4.0.0"
-      }
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -4336,9 +4236,9 @@
       }
     },
     "camelize-ts": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-2.2.0.tgz",
-      "integrity": "sha512-6jMy83qFmNrJIMQXXU6Bi7VVkyl/nBVvoxcVsGRDA6R01pPZpnO/LaIcx6dijJjHbBA2G0uHY4Irk7LeA274NQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/camelize-ts/-/camelize-ts-3.0.0.tgz",
+      "integrity": "sha512-cgRwKKavoDKLTjO4FQTs3dRBePZp/2Y9Xpud0FhuCOTE86M2cniKN4CCXgRnsyXNMmQMifVHcv6SPaMtTx6ofQ=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -4375,14 +4275,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
-    },
-    "combined-stream": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
-      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "requires": {
-        "delayed-stream": "~1.0.0"
-      }
     },
     "commit-and-tag-version": {
       "version": "11.0.0",
@@ -4893,11 +4785,6 @@
         }
       }
     },
-    "delayed-stream": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
-    },
     "detect-indent": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -5077,21 +4964,6 @@
       "requires": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
-      }
-    },
-    "follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
-    },
-    "form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
       }
     },
     "fs-extra": {
@@ -5657,19 +5529,6 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
-    },
-    "mime-db": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
-      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="
-    },
-    "mime-types": {
-      "version": "2.1.35",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
-      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "requires": {
-        "mime-db": "1.52.0"
-      }
     },
     "mimic-fn": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@s3pweb/keycloak-admin-client-cjs",
-  "version": "21.0.1",
+  "version": "22.0.1",
   "description": "Keycloak Admin Client compiled in CommonJS.",
   "keywords": [
     "keycloak-admin-client",
@@ -22,7 +22,7 @@
   "author": "s3pweb",
   "license": "MIT",
   "dependencies": {
-    "@keycloak/keycloak-admin-client": "21.0.1"
+    "@keycloak/keycloak-admin-client": "22.0.1"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.4.2",


### PR DESCRIPTION
Hi @s3pweb, this PR bumps the Keycloak version to 22.0.1 and re-exports the keycloak interfaces in index.d.ts. Otherwise you can't use any keycloak interfaces in a commonjs app like Nest.js.